### PR TITLE
LSM Trees

### DIFF
--- a/storage-retrieval/lsm-trees/go.mod
+++ b/storage-retrieval/lsm-trees/go.mod
@@ -1,0 +1,3 @@
+module table
+
+go 1.16

--- a/storage-retrieval/lsm-trees/table.go
+++ b/storage-retrieval/lsm-trees/table.go
@@ -1,0 +1,44 @@
+package table
+
+type Item struct {
+	Key, Value string
+}
+
+// Given a sorted list of key/value pairs, write them out according to the format you designed.
+func Build(path string, sortedItems []Item) error {
+	return nil
+}
+
+// A Table provides efficient access into sorted key/value data that's organized according
+// to the format you designed.
+//
+// Although a Table shouldn't keep all the key/value data in memory, it should contain
+// some metadata to help with efficient access (e.g. size, index, optional Bloom filter).
+type Table struct {
+	// TODO
+}
+
+// Prepares a Table for efficient access. This will likely involve reading some metadata
+// in order to populate the fields of the Table struct.
+func LoadTable(path string) (*Table, error) {
+	return nil, nil
+}
+
+func (t *Table) Get(key string) (string, bool, error) {
+	return "", false, nil
+}
+
+func (t *Table) RangeScan(startKey, endKey string) (Iterator, error) {
+	return nil, nil
+}
+
+type Iterator interface {
+	// Advances to the next item in the range. Assumes Valid() == true.
+	Next()
+
+	// Indicates whether the iterator is currently pointing to a valid item.
+	Valid() bool
+
+	// Returns the Item the iterator is currently pointing to. Assumes Valid() == true.
+	Item() Item
+}

--- a/storage-retrieval/lsm-trees/table.go
+++ b/storage-retrieval/lsm-trees/table.go
@@ -8,6 +8,8 @@ import (
 	"sort"
 )
 
+const BLOCK_CAPACITY = 4096
+
 type Item struct {
 	Key, Value string
 }
@@ -16,53 +18,65 @@ type Item struct {
 func Build(path string, sortedItems []Item) error {
 	data := new(bytes.Buffer)
 	index := new(bytes.Buffer)
-	var dataOffset uint64 = 0
-	var indexLen uint64 = 0
-	var err error
+	blockSize := 0
+	var blockOffset uint64 = 0
+	var lastKey string
 	for _, item := range sortedItems {
-		keyLen := uint16(len(item.Key))
-		valLen := uint16(len(item.Value))
+		buf := new(bytes.Buffer)
+		// Write the keys and values to a temporary buffer
+		keyLen, err1 := buf.WriteString(item.Key)
+		valLen, err2 := buf.WriteString(item.Value)
+		elemSize := (4 + keyLen + valLen)
 
-		// Write an index entry, containing the value's offset into the data
-		// portion of the file, the length of the value, length of the key, and the
-		// key itself
-		entry := &IndexEntry{dataOffset, valLen, keyLen}
-		err = binary.Write(index, binary.BigEndian, entry)
-		if err != nil {
+		// If the current element will not fit in block, pad out the remaining
+		// bytes with 0s, start a new block and write the previous key to the index
+		if (blockSize + elemSize) > BLOCK_CAPACITY {
+			data.Write(make([]byte, BLOCK_CAPACITY-blockSize))
+			// binary.Write(index, binary.BigEndian, uint64(blockOffset))
+			binary.Write(index, binary.BigEndian, uint16(len(lastKey)))
+			index.WriteString(lastKey)
+			blockSize = 0
+			blockOffset++
+		}
+		blockSize += elemSize
+
+		// Write the elements to the data:
+		// key length, value length, key, value
+		err3 := binary.Write(data, binary.BigEndian, uint16(keyLen))
+		err4 := binary.Write(data, binary.BigEndian, uint16(valLen))
+		_, err5 := data.Write(buf.Bytes())
+
+		lastKey = item.Key
+		// Something went wrong writing to the buffers, bail and return the first
+		// error that occured
+		if err := check(err1, err2, err3, err4, err5); err != nil {
 			return err
 		}
-		_, err = index.WriteString(item.Key)
-		if err != nil {
-			return err
-		}
-
-		// Write the value in data portion of file
-		_, err = data.WriteString(item.Value)
-		if err != nil {
-			return err
-		}
-
-		indexLen += uint64(keyLen + 12)
-		dataOffset += uint64(valLen)
 	}
+	// Pad out the final block and write it to the index
+	data.Write(make([]byte, BLOCK_CAPACITY-blockSize))
+	binary.Write(index, binary.BigEndian, uint16(len(lastKey)))
+	index.WriteString(lastKey)
+
+	// File looks like:
+	// <-- data section   -->
+	// <-- index section  -->
+	// <-- footer section -->
 	file := new(bytes.Buffer)
-	// Place the length of the index as the first two bytes in the file, then
-	// write the index and data
-	err = binary.Write(file, binary.BigEndian, indexLen)
-	if err != nil {
-		return err
-	}
-	_, err = file.Write(index.Bytes())
-	if err != nil {
-		return err
-	}
-	_, err = file.Write(data.Bytes())
-	if err != nil {
-		return err
-	}
-	err = ioutil.WriteFile(path, file.Bytes(), 0644)
-	if err != nil {
-		return err
+	_, err1 := file.Write(data.Bytes())
+	_, err2 := file.Write(index.Bytes())
+	err3 := binary.Write(file, binary.BigEndian, blockOffset+1)
+	err4 := ioutil.WriteFile(path, file.Bytes(), 0644)
+
+	// Will return whatever error happened first when writing the file
+	return check(err1, err2, err3, err4)
+}
+
+func check(errs ...error) error {
+	for _, err := range errs {
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -73,77 +87,80 @@ func Build(path string, sortedItems []Item) error {
 // Although a Table shouldn't keep all the key/value data in memory, it should contain
 // some metadata to help with efficient access (e.g. size, index, optional Bloom filter).
 type Table struct {
-	indexLen uint64
-	index    map[string]IndexEntry
-	keys     []string
-	file     *os.File
-}
-
-type IndexEntry struct {
-	Offset uint64
-	ValLen uint16
-	KeyLen uint16
+	index     []string
+	numBlocks uint64
+	keys      []string
+	file      *os.File
 }
 
 // Prepares a Table for efficient access. This will likely involve reading some metadata
 // in order to populate the fields of the Table struct.
 func LoadTable(path string) (*Table, error) {
 	f, err := os.Open(path)
-	if err != nil {
-		return nil, err
-	}
+	fi, err := f.Stat()
+	fileSize := uint64(fi.Size())
 	d := make([]byte, 8)
-	_, err = f.Read(d)
-	if err != nil {
-		return nil, err
-	}
-	indexLen := binary.BigEndian.Uint64(d)
+	_, err = f.ReadAt(d, int64(fileSize-8))
+	numBlocks := binary.BigEndian.Uint64(d)
+	dataSize := numBlocks * BLOCK_CAPACITY
 
-	indexBytes := make([]byte, indexLen)
-	_, err = f.ReadAt(indexBytes, 8)
+	indexBytes := make([]byte, fileSize-dataSize-8)
+	_, err = f.ReadAt(indexBytes, int64(dataSize))
 	if err != nil {
 		return nil, err
 	}
-	index := make(map[string]IndexEntry)
+	index := make([]string, numBlocks)
 	keys := make([]string, 1)
 
-	var i uint64 = 0
-	for i < indexLen {
-		entry := new(IndexEntry)
-		r := bytes.NewReader(indexBytes[i : i+12])
-		err = binary.Read(r, binary.BigEndian, entry)
+	i := uint64(0)
+	block := 0
+	for i < uint64(len(indexBytes)) {
+		keyLen := uint64(binary.BigEndian.Uint16(indexBytes[i : i+2]))
+		key := string(indexBytes[i+2 : i+2+keyLen])
+		index[block] = key
 		if err != nil {
 			return nil, err
 		}
-		i += 12
-
-		key := string(indexBytes[i : i+uint64(entry.KeyLen)])
-		keys = append(keys, key)
-		index[key] = *entry
-		i += uint64(entry.KeyLen)
+		i += (2 + keyLen)
+		block++
 	}
 
 	t := &Table{
-		file:     f,
-		indexLen: indexLen,
-		index:    index,
-		keys:     keys,
+		file:      f,
+		index:     index,
+		numBlocks: numBlocks,
+		keys:      keys,
 	}
 
 	return t, nil
 }
 
 func (t *Table) Get(key string) (string, bool, error) {
-	entry, ok := t.index[key]
-	if !ok {
+	// Binary Search the blocks to find the block where the key might reside
+	blockOffset := uint64(sort.SearchStrings(t.index, key))
+	// If the blockOffset is equal to the number of blocks, it means the key is
+	// greater than all the elements in the table, and hence is not in the table
+	if blockOffset == t.numBlocks {
 		return "", false, nil
 	}
-	value := make([]byte, entry.ValLen)
-	_, err := t.file.ReadAt(value, int64(entry.Offset+t.indexLen+8))
-	if err != nil {
-		return "", false, err
+
+	// Read the block into memory and linear scan to find the key. This is OK
+	// because each block is fixed and small-ish (4kb). A binary search would
+	// improve the constant factor, so we can consider this a TODO optimization
+	block := make([]byte, BLOCK_CAPACITY)
+	t.file.ReadAt(block, int64(blockOffset*BLOCK_CAPACITY))
+	i := uint64(0)
+	for i < BLOCK_CAPACITY {
+		keyLen := uint64(binary.BigEndian.Uint16(block[i : i+2]))
+		valLen := uint64(binary.BigEndian.Uint16(block[i+2 : i+4]))
+		k := string(block[i+4 : i+4+keyLen])
+		if k == key {
+			val := string(block[i+4+keyLen : i+4+keyLen+valLen])
+			return val, true, nil
+		}
+		i += (4 + keyLen + valLen)
 	}
-	return string(value), true, nil
+	return "", false, nil
 }
 
 func (t *Table) RangeScan(startKey, endKey string) (Iterator, error) {

--- a/storage-retrieval/lsm-trees/table.go
+++ b/storage-retrieval/lsm-trees/table.go
@@ -1,11 +1,46 @@
 package table
 
+import (
+	"bytes"
+	"encoding/binary"
+	"io/ioutil"
+	"os"
+)
+
 type Item struct {
 	Key, Value string
 }
 
 // Given a sorted list of key/value pairs, write them out according to the format you designed.
 func Build(path string, sortedItems []Item) error {
+	data := new(bytes.Buffer)
+	index := new(bytes.Buffer)
+	var dataOffset uint16 = 0
+	var indexLen uint16 = 0
+	for _, item := range sortedItems {
+		keyLen := uint16(len(item.Key))
+		valLen := uint16(len(item.Value))
+
+		// Write an index entry, containing the value's offset into the data
+		// portion of the file, the length of the value, length of the key, and the
+		// key itself
+		entry := &IndexEntry{dataOffset, valLen, keyLen}
+		binary.Write(index, binary.BigEndian, entry)
+		index.WriteString(item.Key)
+
+		// Write the value in data portion of file
+		data.WriteString(item.Value)
+
+		indexLen += (keyLen + 6)
+		dataOffset += valLen
+	}
+	file := new(bytes.Buffer)
+	// Place the length of the index as the first two bytes in the file, then
+	// write the index and data
+	binary.Write(file, binary.BigEndian, indexLen)
+	file.Write(index.Bytes())
+	file.Write(data.Bytes())
+	ioutil.WriteFile(path, file.Bytes(), 0644)
 	return nil
 }
 
@@ -15,17 +50,58 @@ func Build(path string, sortedItems []Item) error {
 // Although a Table shouldn't keep all the key/value data in memory, it should contain
 // some metadata to help with efficient access (e.g. size, index, optional Bloom filter).
 type Table struct {
-	// TODO
+	indexLen uint16
+	index    map[string]IndexEntry
+	file     *os.File
+}
+
+type IndexEntry struct {
+	Offset uint16
+	ValLen uint16
+	KeyLen uint16
 }
 
 // Prepares a Table for efficient access. This will likely involve reading some metadata
 // in order to populate the fields of the Table struct.
 func LoadTable(path string) (*Table, error) {
-	return nil, nil
+	f, _ := os.Open(path)
+	d := make([]byte, 2)
+	f.Read(d)
+	indexLen := binary.BigEndian.Uint16(d)
+
+	indexBytes := make([]byte, indexLen)
+	f.ReadAt(indexBytes, 2)
+	index := make(map[string]IndexEntry)
+
+	var i uint16 = 0
+	for i < indexLen {
+		entry := new(IndexEntry)
+		r := bytes.NewReader(indexBytes[i : i+6])
+		binary.Read(r, binary.BigEndian, entry)
+		i += 6
+
+		key := string(indexBytes[i : i+entry.KeyLen])
+		index[key] = *entry
+		i += entry.KeyLen
+	}
+
+	t := &Table{
+		file:     f,
+		indexLen: indexLen,
+		index:    index,
+	}
+
+	return t, nil
 }
 
 func (t *Table) Get(key string) (string, bool, error) {
-	return "", false, nil
+	entry, ok := t.index[key]
+	if !ok {
+		return "", false, nil
+	}
+	value := make([]byte, entry.ValLen)
+	t.file.ReadAt(value, int64(entry.Offset+t.indexLen+2))
+	return string(value), true, nil
 }
 
 func (t *Table) RangeScan(startKey, endKey string) (Iterator, error) {

--- a/storage-retrieval/lsm-trees/table_test.go
+++ b/storage-retrieval/lsm-trees/table_test.go
@@ -1,0 +1,110 @@
+package table
+
+import (
+	"bytes"
+	"io/ioutil"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+)
+
+// min and max are inclusive.
+func randomWord(min, max int) string {
+	n := min + rand.Intn(max-min+1)
+	var buf bytes.Buffer
+	for i := 0; i < n; i++ {
+		c := rune(rand.Intn(26))
+		buf.WriteRune('a' + c)
+	}
+	return buf.String()
+}
+
+// All items are guaranteed to have unique keys.
+func generateSortedItems(n int) []Item {
+	m := make(map[string]struct{}, n)
+	for len(m) < n {
+		key := randomWord(8, 16)
+		m[key] = struct{}{}
+	}
+	keys := make([]string, 0, n)
+	for key := range m {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	result := make([]Item, n)
+	for i, key := range keys {
+		value := randomWord(10, 20)
+		result[i] = Item{key, value}
+	}
+	return result
+}
+
+func TestTable(t *testing.T) {
+	dir, err := ioutil.TempDir("", "table")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Clean up temp directory at end of test; you can remove this for debugging.
+	defer os.RemoveAll(dir)
+
+	tmpfile := filepath.Join(dir, "tmpfile")
+
+	n := 1000
+	sortedItems := generateSortedItems(n)
+
+	toInclude := sortedItems[:n/2]
+	toExclude := sortedItems[n/2:]
+
+	err = Build(tmpfile, toInclude)
+	if err != nil {
+		t.Fatalf("Error building Table: %v", err)
+	}
+
+	table, err := LoadTable(tmpfile)
+	if err != nil {
+		t.Fatalf("Error loading Table: %v", err)
+	}
+
+	for _, item := range toInclude {
+		actual, ok, err := table.Get(item.Key)
+		if err != nil {
+			t.Fatalf("Error performing point read for key %q: %v", item.Key, err)
+		}
+		if !ok {
+			t.Fatalf("Expected key %q to exist", item.Key)
+		}
+		if actual != item.Value {
+			t.Fatalf("Key %q: expected value %q, got %q instead", item.Key, item.Value, actual)
+		}
+	}
+
+	for _, item := range toExclude {
+		_, ok, err := table.Get(item.Key)
+		if err != nil {
+			t.Fatalf("Error performing point read for key %q: %v", item.Key, err)
+		}
+		if ok {
+			t.Fatalf("Expected key %q not to exist", item.Key)
+		}
+	}
+
+	// TODO: Uncomment the following to test RangeScan
+	/*
+		expectedScan := sortedItems[n/4 : n/3]
+		startKey := expectedScan[0].Key
+		endKey := expectedScan[len(expectedScan)-1].Key
+		iter, err := table.RangeScan(startKey, endKey)
+		if err != nil {
+			t.Fatal(err)
+		}
+		actualScan := make([]Item, 0, len(expectedScan))
+		for ; iter.Valid(); iter.Next() {
+			actualScan = append(actualScan, iter.Item())
+		}
+		if !reflect.DeepEqual(expectedScan, actualScan) {
+			t.Fatalf("Unexpected RangeScan result\n\nExpected: %v\n\nActual: %v", expectedScan, actualScan)
+		}
+	*/
+}

--- a/storage-retrieval/lsm-trees/table_test.go
+++ b/storage-retrieval/lsm-trees/table_test.go
@@ -6,6 +6,7 @@ import (
 	"math/rand"
 	"os"
 	"path/filepath"
+	"reflect"
 	"sort"
 	"testing"
 )
@@ -90,21 +91,18 @@ func TestTable(t *testing.T) {
 		}
 	}
 
-	// TODO: Uncomment the following to test RangeScan
-	/*
-		expectedScan := sortedItems[n/4 : n/3]
-		startKey := expectedScan[0].Key
-		endKey := expectedScan[len(expectedScan)-1].Key
-		iter, err := table.RangeScan(startKey, endKey)
-		if err != nil {
-			t.Fatal(err)
-		}
-		actualScan := make([]Item, 0, len(expectedScan))
-		for ; iter.Valid(); iter.Next() {
-			actualScan = append(actualScan, iter.Item())
-		}
-		if !reflect.DeepEqual(expectedScan, actualScan) {
-			t.Fatalf("Unexpected RangeScan result\n\nExpected: %v\n\nActual: %v", expectedScan, actualScan)
-		}
-	*/
+	expectedScan := sortedItems[n/4 : n/3]
+	startKey := expectedScan[0].Key
+	endKey := expectedScan[len(expectedScan)-1].Key
+	iter, err := table.RangeScan(startKey, endKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	actualScan := make([]Item, 0, len(expectedScan))
+	for ; iter.Valid(); iter.Next() {
+		actualScan = append(actualScan, iter.Item())
+	}
+	if !reflect.DeepEqual(expectedScan, actualScan) {
+		t.Fatalf("Unexpected RangeScan result\n\nExpected: %v\n\nActual: %v", expectedScan, actualScan)
+	}
 }

--- a/storage-retrieval/lsm-trees/table_test.go
+++ b/storage-retrieval/lsm-trees/table_test.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"math/rand"
 	"path/filepath"
+	"reflect"
 	"sort"
 	"testing"
 )
@@ -91,18 +92,18 @@ func TestTable(t *testing.T) {
 		}
 	}
 
-	// expectedScan := sortedItems[n/4 : n/3]
-	// startKey := expectedScan[0].Key
-	// endKey := expectedScan[len(expectedScan)-1].Key
-	// iter, err := table.RangeScan(startKey, endKey)
-	// if err != nil {
-	// 	t.Fatal(err)
-	// }
-	// actualScan := make([]Item, 0, len(expectedScan))
-	// for ; iter.Valid(); iter.Next() {
-	// 	actualScan = append(actualScan, iter.Item())
-	// }
-	// if !reflect.DeepEqual(expectedScan, actualScan) {
-	// 	t.Fatalf("Unexpected RangeScan result\n\nExpected: %v\n\nActual: %v", expectedScan, actualScan)
-	// }
+	expectedScan := sortedItems[n/4 : n/3]
+	startKey := expectedScan[0].Key
+	endKey := expectedScan[len(expectedScan)-1].Key
+	iter, err := table.RangeScan(startKey, endKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	actualScan := make([]Item, 0, len(expectedScan))
+	for ; iter.Valid(); iter.Next() {
+		actualScan = append(actualScan, iter.Item())
+	}
+	if !reflect.DeepEqual(expectedScan, actualScan) {
+		t.Fatalf("Unexpected RangeScan result\n\nExpected: %v\n\nActual: %v", expectedScan, actualScan)
+	}
 }

--- a/storage-retrieval/lsm-trees/table_test.go
+++ b/storage-retrieval/lsm-trees/table_test.go
@@ -2,11 +2,10 @@ package table
 
 import (
 	"bytes"
+	"fmt"
 	"io/ioutil"
 	"math/rand"
-	"os"
 	"path/filepath"
-	"reflect"
 	"sort"
 	"testing"
 )
@@ -48,9 +47,10 @@ func TestTable(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Clean up temp directory at end of test; you can remove this for debugging.
-	defer os.RemoveAll(dir)
+	// defer os.RemoveAll(dir)
 
 	tmpfile := filepath.Join(dir, "tmpfile")
+	fmt.Printf("%s\n", tmpfile)
 
 	n := 1000
 	sortedItems := generateSortedItems(n)
@@ -91,18 +91,18 @@ func TestTable(t *testing.T) {
 		}
 	}
 
-	expectedScan := sortedItems[n/4 : n/3]
-	startKey := expectedScan[0].Key
-	endKey := expectedScan[len(expectedScan)-1].Key
-	iter, err := table.RangeScan(startKey, endKey)
-	if err != nil {
-		t.Fatal(err)
-	}
-	actualScan := make([]Item, 0, len(expectedScan))
-	for ; iter.Valid(); iter.Next() {
-		actualScan = append(actualScan, iter.Item())
-	}
-	if !reflect.DeepEqual(expectedScan, actualScan) {
-		t.Fatalf("Unexpected RangeScan result\n\nExpected: %v\n\nActual: %v", expectedScan, actualScan)
-	}
+	// expectedScan := sortedItems[n/4 : n/3]
+	// startKey := expectedScan[0].Key
+	// endKey := expectedScan[len(expectedScan)-1].Key
+	// iter, err := table.RangeScan(startKey, endKey)
+	// if err != nil {
+	// 	t.Fatal(err)
+	// }
+	// actualScan := make([]Item, 0, len(expectedScan))
+	// for ; iter.Valid(); iter.Next() {
+	// 	actualScan = append(actualScan, iter.Item())
+	// }
+	// if !reflect.DeepEqual(expectedScan, actualScan) {
+	// 	t.Fatalf("Unexpected RangeScan result\n\nExpected: %v\n\nActual: %v", expectedScan, actualScan)
+	// }
 }


### PR DESCRIPTION
When the file is opened, the index section is read into memory (with the help of the two-byte header section to find where to stop reading the index) and stored as a map of the string key to the offset values. A point read looks up the key in the map and then seeks to that offset in the file.

The file format has three sections.

Section 1: Header (8 bytes)
---------------------------
A uint64 representing the length of the Index section

Section 2: Index (len(index) bytes)
-----------------------------------
These are index entries packed one after the other. Each entry has a twelve-byte header followed by the key itself. The twelve-byte header consists of: the value's offset (uint64) into the data section as well as the length of the key and value strings (both uint16).

Section 3: Data (len(values) bytes)
-----------------------------------
These are simply the values themselves packed one after the other.

The keys array is the simplest thing I could think of for range scans, but it's not particularly memory efficient since we're storing the keys twice in memory (once in the index, once in this array). But this approach supports the feature without any modifications to the file format and doesn't require any extra passes through the data structure when reading the index, so seemed reasonable.