### PR TITLE
Single table queries

### DIFF
--- a/database-systems/single-table-queries/executor.go
+++ b/database-systems/single-table-queries/executor.go
@@ -1,13 +1,23 @@
 package main
 
-import "fmt"
+import (
+	"encoding/csv"
+	"fmt"
+	"os"
+)
+
+type movie struct {
+	movieId string
+	title   string
+	genres  string
+}
 
 type Node interface {
-	Next() []string
+	Next() movie
 }
 
 type SeqScanNode struct {
-	data   [][]string
+	data   []*movie
 	nRows  int
 	cursor int
 	child  *Node
@@ -20,11 +30,23 @@ type LimitNode struct {
 }
 
 func newSeqScanNode() *SeqScanNode {
-	data := [][]string{
-		{"a1", "a2", "a3"},
-		{"b1", "b2", "b3"},
-		{"c1", "c2", "c3"},
+	data := make([]*movie, 0)
+	f, err := os.Open("data/movies.csv")
+	if err != nil {
+		fmt.Printf("Could not open movies file.")
+		return nil
 	}
+	r := csv.NewReader(f)
+	r.Read() // Skip header
+	movies, err := r.ReadAll()
+	if err != nil {
+		fmt.Printf("Could not read movies file.")
+		return nil
+	}
+	for _, m := range movies {
+		data = append(data, &movie{m[0], m[1], m[2]})
+	}
+
 	return &SeqScanNode{
 		data:   data,
 		nRows:  len(data),
@@ -37,16 +59,15 @@ func newLimitNode(limit int, child *SeqScanNode) *LimitNode {
 	return &LimitNode{limit: limit, cursor: 0, child: child}
 }
 
-func (l *LimitNode) Next() []string {
+func (l *LimitNode) Next() *movie {
 	if l.cursor < l.limit {
-		//fmt.Printf("c: %+v\n", c)
 		l.cursor++
 		return l.child.Next()
 	}
 	return nil
 }
 
-func (s *SeqScanNode) Next() []string {
+func (s *SeqScanNode) Next() *movie {
 	if s.cursor >= s.nRows {
 		return nil
 	}
@@ -57,9 +78,9 @@ func (s *SeqScanNode) Next() []string {
 }
 
 func main() {
-	fmt.Println("Executing: SELECT * FROM test LIMIT 2")
+	fmt.Println("Executing: SELECT * FROM test LIMIT 5")
 	s := newSeqScanNode()
-	l := newLimitNode(2, s)
+	l := newLimitNode(5, s)
 	for row := l.Next(); row != nil; row = l.Next() {
 		fmt.Printf("%+v\n", row)
 	}

--- a/database-systems/single-table-queries/executor.go
+++ b/database-systems/single-table-queries/executor.go
@@ -2,6 +2,65 @@ package main
 
 import "fmt"
 
+type Node interface {
+	Next() []string
+}
+
+type SeqScanNode struct {
+	data   [][]string
+	nRows  int
+	cursor int
+	child  *Node
+}
+
+type LimitNode struct {
+	limit  int
+	cursor int
+	child  *SeqScanNode
+}
+
+func newSeqScanNode() *SeqScanNode {
+	data := [][]string{
+		{"a1", "a2", "a3"},
+		{"b1", "b2", "b3"},
+		{"c1", "c2", "c3"},
+	}
+	return &SeqScanNode{
+		data:   data,
+		nRows:  len(data),
+		cursor: 0,
+		child:  nil,
+	}
+}
+
+func newLimitNode(limit int, child *SeqScanNode) *LimitNode {
+	return &LimitNode{limit: limit, cursor: 0, child: child}
+}
+
+func (l *LimitNode) Next() []string {
+	if l.cursor < l.limit {
+		//fmt.Printf("c: %+v\n", c)
+		l.cursor++
+		return l.child.Next()
+	}
+	return nil
+}
+
+func (s *SeqScanNode) Next() []string {
+	if s.cursor >= s.nRows {
+		return nil
+	}
+
+	row := s.data[s.cursor]
+	s.cursor++
+	return row
+}
+
 func main() {
-	fmt.Println("I am a query executor.")
+	fmt.Println("Executing: SELECT * FROM test LIMIT 2")
+	s := newSeqScanNode()
+	l := newLimitNode(2, s)
+	for row := l.Next(); row != nil; row = l.Next() {
+		fmt.Printf("%+v\n", row)
+	}
 }

--- a/database-systems/single-table-queries/executor.go
+++ b/database-systems/single-table-queries/executor.go
@@ -26,7 +26,22 @@ type SeqScanNode struct {
 type LimitNode struct {
 	limit  int
 	cursor int
-	child  *SeqScanNode
+	child  *SelectionNode
+}
+
+type SelectionNode struct {
+	pred  PredFn
+	child *SeqScanNode
+}
+
+type PredFn func(*movie) bool
+
+func newLimitNode(limit int, child *SelectionNode) *LimitNode {
+	return &LimitNode{limit: limit, cursor: 0, child: child}
+}
+
+func newSelectionNode(pred PredFn, child *SeqScanNode) *SelectionNode {
+	return &SelectionNode{pred: pred, child: child}
 }
 
 func newSeqScanNode() *SeqScanNode {
@@ -55,14 +70,19 @@ func newSeqScanNode() *SeqScanNode {
 	}
 }
 
-func newLimitNode(limit int, child *SeqScanNode) *LimitNode {
-	return &LimitNode{limit: limit, cursor: 0, child: child}
-}
-
 func (l *LimitNode) Next() *movie {
 	if l.cursor < l.limit {
 		l.cursor++
 		return l.child.Next()
+	}
+	return nil
+}
+
+func (s *SelectionNode) Next() *movie {
+	for m := s.child.Next(); m != nil; m = s.child.Next() {
+		if s.pred(m) {
+			return m
+		}
 	}
 	return nil
 }
@@ -78,10 +98,25 @@ func (s *SeqScanNode) Next() *movie {
 }
 
 func main() {
-	fmt.Println("Executing: SELECT * FROM test LIMIT 5")
+	// First Test Query
+	fmt.Println("Executing: SELECT * FROM movies LIMIT 5")
+	pred := func(m *movie) bool {
+		return true
+	}
 	s := newSeqScanNode()
-	l := newLimitNode(5, s)
+	sel := newSelectionNode(pred, s)
+	l := newLimitNode(5, sel)
 	for row := l.Next(); row != nil; row = l.Next() {
+		fmt.Printf("%+v\n", row)
+	}
+
+	// Second Test Query
+	fmt.Println("\nExecuting: SELECT * FROM movies WHERE id = 5000")
+	pred = func(m *movie) bool {
+		return m.movieId == "5000"
+	}
+	sel2 := newSelectionNode(pred, s)
+	for row := sel2.Next(); row != nil; row = sel2.Next() {
 		fmt.Printf("%+v\n", row)
 	}
 }

--- a/database-systems/single-table-queries/executor.go
+++ b/database-systems/single-table-queries/executor.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("I am a query executor.")
+}

--- a/database-systems/single-table-queries/executor_test.go
+++ b/database-systems/single-table-queries/executor_test.go
@@ -1,0 +1,37 @@
+package main
+
+import "testing"
+
+func TestLimit(t *testing.T) {
+	lim := 5
+	s := newSeqScanNode()
+	root := newLimitNode(lim, s)
+
+	rows := Execute(root)
+
+	if len(rows) != lim {
+		t.Fatalf("SELECT * FROM movies LIMIT 5\nReturned %d rows, want %d rows",
+			len(rows),
+			lim,
+		)
+	}
+}
+
+func TestSelection(t *testing.T) {
+	pred := func(m *movie) bool {
+		return m.movieId == "5000"
+	}
+	id := "5000"
+	s := newSeqScanNode()
+	root := newSelectionNode(pred, s)
+
+	rows := Execute(root)
+	movie := rows[0]
+
+	if movie.movieId != id {
+		t.Fatalf("SELECT * FROM movies WHERE id = 5000\nReturned id %s, wanted movieId %s",
+			movie.movieId,
+			id,
+		)
+	}
+}

--- a/database-systems/single-table-queries/go.mod
+++ b/database-systems/single-table-queries/go.mod
@@ -1,0 +1,3 @@
+module executor
+
+go 1.16


### PR DESCRIPTION
This is pretty rough and I'm not even sure it's how it's supposed to work, but I implemented:
* SeqScan
* Selection
* Projection
* Limit
* Sort

I did not do any parsing of a serialized representation of the query, so it's just built up in memory. If you have the MovieLens data in sub-directory called `data` you can run it for a couple sample queries.

```sh
$ go run

Sample Query 1
==============
Executing: SELECT title FROM movies WHERE id = 5000
map[title:Medium Cool (1969)]

Sample Query 2
==============
Executing: SELECT title, genres FROM movies ORDER BY genres, title DESC LIMIT 3
map[genres:(no genres listed) title:Zanjeer (1973)]
map[genres:(no genres listed) title:Wuthering Heights (2003)]
map[genres:(no genres listed) title:Women Aren't Funny (2014)]
```